### PR TITLE
fix: borner les pré-allocations pilotées par le paquet, exposer les erreurs par couche

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -5,11 +5,15 @@
 
 // errors/mod.rs
 
-pub(crate) mod application;
-pub(crate) mod data_link;
-pub(crate) mod internet;
+// Publics : le doc-comment de `lib.rs` promet aux consommateurs de pouvoir
+// nommer et matcher les types d'erreur par couche. Tant que ces modules
+// étaient `pub(crate)`, la promesse ne compilait pas (E0603) et les 120
+// `validate_*` publics de `checks/` renvoyaient des types innommables.
+pub mod application;
+pub mod data_link;
+pub mod internet;
 mod link_layer;
-pub(crate) mod transport;
+pub mod transport;
 
 use application::ApplicationError;
 use data_link::DataLinkError;

--- a/src/parse/application/protocols/dns/dns_queries/mod.rs
+++ b/src/parse/application/protocols/dns/dns_queries/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use crate::{
     checks::application::dns::check_dns_query_size,
     errors::application::dns::DnsQueryParseError,
+    parse::application::protocols::bounded_capacity,
     parse::application::protocols::dns::utils::{
         dns_class::DnsClass, dns_types::DnsType, name::parse_dns_name,
     },
@@ -34,7 +35,12 @@ impl DnsQueries {
         offset: &mut usize,
         count: u16,
     ) -> Result<Self, DnsQueryParseError> {
-        let mut queries = Vec::with_capacity(count as usize);
+        // Une question pèse au minimum 5 octets : nom racine 1 + type 2
+        // + classe 2.
+        const MIN_QUERY_LEN: usize = 5;
+        let remaining = message.len().saturating_sub(*offset);
+        let mut queries =
+            Vec::with_capacity(bounded_capacity(count as usize, remaining, MIN_QUERY_LEN));
         for _ in 0..count {
             check_dns_query_size(message, *offset, 1)?;
             queries.push(DnsQuery::from_bytes(message, offset)?);

--- a/src/parse/application/protocols/dns/mod.rs
+++ b/src/parse/application/protocols/dns/mod.rs
@@ -12,6 +12,7 @@ pub mod utils;
 
 use crate::{
     checks::application::dns::check_dns_minimum_size, errors::application::dns::DnsPacketError,
+    parse::application::protocols::bounded_capacity,
 };
 use dns_additional::AdditionalRecord;
 use dns_answers::Answer;
@@ -85,7 +86,12 @@ fn parse_record_section<T: From<RawRecord>>(
     if count == 0 {
         return Ok(None);
     }
-    let mut records = Vec::with_capacity(count as usize);
+    // Un RR pèse au minimum 11 octets : nom racine 1 + type 2 + classe 2
+    // + TTL 4 + rdlength 2.
+    const MIN_RECORD_LEN: usize = 11;
+    let remaining = message.len().saturating_sub(*offset);
+    let mut records =
+        Vec::with_capacity(bounded_capacity(count as usize, remaining, MIN_RECORD_LEN));
     for _ in 0..count {
         records.push(T::from(parse_resource_record(message, offset)?));
     }

--- a/src/parse/application/protocols/ethernet_ip.rs
+++ b/src/parse/application/protocols/ethernet_ip.rs
@@ -14,6 +14,7 @@ use crate::{
         validate_register_session_length,
     },
     errors::application::ethernet_ip::EtherNetIpError,
+    parse::application::protocols::bounded_capacity,
 };
 
 #[cfg_attr(all(doc, feature = "doc-diagrams"), aquamarine::aquamarine)]
@@ -214,7 +215,10 @@ fn parse_common_packet_format<'a>(
     let item_count = u16::from_le_bytes([data[6], data[7]]) as usize;
 
     let mut offset = 8usize;
-    let mut items = Vec::with_capacity(item_count);
+    // Un item CPF pèse au minimum 4 octets : type_id 2 + length 2.
+    const MIN_CPF_ITEM_LEN: usize = 4;
+    let remaining = data.len().saturating_sub(offset);
+    let mut items = Vec::with_capacity(bounded_capacity(item_count, remaining, MIN_CPF_ITEM_LEN));
 
     for _ in 0..item_count {
         let item_header_end = offset + 4;

--- a/src/parse/application/protocols/mod.rs
+++ b/src/parse/application/protocols/mod.rs
@@ -43,6 +43,56 @@ pub mod snmp;
 pub mod srvloc;
 pub mod tls;
 
+/// Borne une pré-allocation dimensionnée par un champ du paquet.
+///
+/// Les compteurs d'éléments (`ancount` DNS, `item_count` EtherNet/IP…) sont
+/// sous contrôle de l'émetteur : les utiliser tels quels dans
+/// `Vec::with_capacity` permet à 17 octets de payload de réserver 4 Mo. Comme
+/// le profil release déclare `panic = "abort"`, un échec d'allocation tue le
+/// processus au lieu de remonter une erreur.
+///
+/// La borne ne change pas le comportement observable : les boucles de parsing
+/// échouent de toute façon sur des données tronquées. Seule la mémoire
+/// réservée d'avance est plafonnée à ce que les octets restants peuvent
+/// réellement contenir.
+///
+/// `min_item_len` doit être la taille minimale d'un élément, en octets, et
+/// être non nul.
+pub(crate) fn bounded_capacity(count: usize, remaining: usize, min_item_len: usize) -> usize {
+    debug_assert!(min_item_len > 0, "min_item_len doit être non nul");
+    count.min(remaining / min_item_len.max(1))
+}
+
+#[cfg(test)]
+mod bounded_capacity_tests {
+    use super::bounded_capacity;
+
+    #[test]
+    fn keeps_the_count_when_the_buffer_can_hold_it() {
+        // 32 réponses DNS de 16 octets : la pré-allocation reste utile.
+        assert_eq!(bounded_capacity(32, 512, 11), 32);
+    }
+
+    #[test]
+    fn clamps_a_hostile_count_to_the_available_bytes() {
+        // `ancount = 0xFFFF` avec 5 octets restants : 4 Mo réclamés, 0 accordé.
+        assert_eq!(bounded_capacity(65_535, 5, 11), 0);
+        // Le cas réel de l'audit : 17 octets de payload, en-tête consommé.
+        assert_eq!(bounded_capacity(65_535, 17, 11), 1);
+    }
+
+    #[test]
+    fn handles_an_exhausted_buffer() {
+        assert_eq!(bounded_capacity(65_535, 0, 11), 0);
+    }
+
+    #[test]
+    fn never_exceeds_the_declared_count() {
+        // Un gros buffer ne doit pas gonfler la réservation au-delà du besoin.
+        assert_eq!(bounded_capacity(3, 65_535, 4), 3);
+    }
+}
+
 /// The `ApplicationProtocol` enum represents the possible layer 7 information that can be parsed.
 #[derive(Debug)]
 pub enum ApplicationProtocol<'a> {

--- a/src/parse/application/protocols/postgresql.rs
+++ b/src/parse/application/protocols/postgresql.rs
@@ -773,6 +773,11 @@ fn parse_bind(body: &[u8]) -> Result<PostgreSqlBind<'_>, PostgreSqlError> {
     }
 
     let value_count = cur.read_u16("parameter_value_count")? as usize;
+    // Symétrique de `parameter_type_oids` (l.746), `parameter_formats` (l.768)
+    // et `result_formats` (l.796) : chaque valeur porte au minimum son préfixe
+    // de longueur de 4 octets. Sans cette garde, `value_count = 0xFFFF` sur
+    // 11 octets de payload pré-alloue 1 Mo.
+    validate_remaining(cur.remaining(), value_count * 4, "parameter_values")?;
     let mut parameter_values = Vec::with_capacity(value_count);
     for _ in 0..value_count {
         let len = cur.read_i32("parameter_value_length")?;


### PR DESCRIPTION
Deux corrections issues de l'audit `docs/audit-8.1.0.md`, sans changement de comportement observable.

## 1. Pré-allocations dimensionnées par un champ attaquant

Quatre `Vec::with_capacity` utilisaient un compteur lu dans le paquet : `dns/mod.rs` (ancount/nscount/arcount), `dns_queries` (qdcount), `ethernet_ip` (item_count), `postgresql` (parameter_value_count).

Mesuré avec un allocateur global instrumenté, en profil release :

| Entrée | Avant | Après |
|---|---|---|
| DNS `ancount=0xFFFF`, 59 o, port arbitraire | 4 194 272 o (×71 089) | **32 o** |
| DNS légitime 32 réponses, 575 o, port 53 | 2 402 o | 2 402 o, verdict L7 inchangé |

Le profil release déclarant `panic = "abort"`, un échec d'allocation tuait le processus au lieu de remonter une erreur.

Les boucles de parsing échouaient déjà sur données tronquées : seule la mémoire réservée d'avance est plafonnée. La borne passe par un helper `bounded_capacity()` unitairement testé (4 tests), plutôt que par trois expressions dupliquées. Le site PostgreSQL reprend `validate_remaining()`, strictement symétrique des trois compteurs voisins de `parse_bind` qui l'utilisaient déjà (l.746, 768, 796).

Closes #19

## 2. Les types d'erreur par couche sont enfin nommables

Le doc-comment de `lib.rs` promettait `errors::internet::InternetError`, mais les modules étaient `pub(crate)` : un consommateur obtenait `E0603`, et les 120 `validate_*` publics de `checks/` renvoyaient des types innommables.

`cargo doc --no-deps` passe de 3 warnings « links to private item » à **zéro**.

Reste ouvert après cette PR : poser `#[non_exhaustive]` sur les 32 enums d'erreur nouvellement exposées — gratuit maintenant, rupture plus tard. Suivi dans #21.

## Vérification

- 744 tests verts (697 unitaires + 34 intégration + 13)
- `cargo fmt -- --check` propre
- `cargo clippy --all-targets --all-features -- -D warnings` silencieux
- `cargo doc --no-deps` sans warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)