### PR TITLE
ci: élargir la CI au workspace et ajouter un fuzzing planifié

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ on:
       - main
   pull_request:
 
-# permissions:
-#   contents: read
-#   actions: write 
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:
@@ -18,7 +20,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
 
@@ -27,17 +29,50 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - name: Check formatting
-        run: cargo fmt -- --check
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
 
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      # --workspace : les 4 crates membres (benchmark_db, ingestor,
+      # integration_test, see_unparsable) n'étaient lintées par rien.
+      # --all-features : la feature parse_timing duplique le pipeline ;
+      # sans ce drapeau, cette moitié du code n'était jamais vérifiée.
       - name: Lint with Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features --verbose
+        run: cargo test --workspace --all-features --verbose
 
       - name: Security audit
-        run: cargo install cargo-audit && cargo audit
+        run: cargo install cargo-audit --locked && cargo audit
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --all-features
+
+  # `fuzz/` est exclu du workspace (il exige cargo-fuzz et nightly), donc rien
+  # ne le compilait : les cibles pourrissaient en silence dès qu'une signature
+  # publique changeait. Ce job ne fuzze pas, il vérifie seulement qu'elles
+  # compilent encore — ~1 min, et le fuzzing planifié reste utilisable.
+  fuzz-targets-build:
+    name: Fuzz targets still compile
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target\nfuzz -> fuzz/target"
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz targets
+        run: cargo +nightly fuzz build

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,79 @@
+name: Fuzz
+
+# Fuzzing planifié : la seule chose qui trouve les panics auxquels personne
+# n'a pensé. Tourne la nuit, ne dit rien quand tout va bien, échoue (donc
+# notifie) uniquement sur crash — avec l'entrée fautive en artefact.
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Durée par cible, en secondes"
+        required: false
+        default: "600"
+  schedule:
+    # 03:17 UTC, décalé de l'heure ronde pour éviter la congestion des runners.
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    # Ne pas arrêter les autres cibles quand une trouve un crash : on veut
+    # savoir en une seule nuit tout ce qui casse, pas seulement le premier.
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - parse_linktype
+          - parse_packetflow
+          - parse_application
+          - parse_dns
+          - parse_quic
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target\nfuzz -> fuzz/target"
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      # Le corpus est conservé d'une nuit sur l'autre : sans lui, chaque run
+      # repart de zéro et ne dépasse jamais la surface la plus superficielle.
+      # La clé porte le run_id pour toujours réécrire ; restore-keys récupère
+      # le corpus de la veille.
+      - name: Restore corpus
+        uses: actions/cache@v4
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Run fuzzer
+        run: |
+          cargo +nightly fuzz run ${{ matrix.target }} -- \
+            -max_total_time=${{ github.event.inputs.duration || '600' }} \
+            -print_final_stats=1
+
+      # `if: failure()` : ne se déclenche que si le fuzzer a trouvé un crash.
+      # L'entrée fautive suffit à reproduire :
+      #   cargo +nightly fuzz run <cible> <fichier>
+      - name: Upload crashing input
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 90


### PR DESCRIPTION
Filet automatique pour pouvoir laisser le dépôt sans surveillance.

## CI (`ci.yml`)

| Avant | Après |
|---|---|
| `cargo clippy --all-targets` | `cargo clippy --workspace --all-targets --all-features` |
| `cargo test --all-features` | `cargo test --workspace --all-features` |
| `cargo build --release` | `cargo build --release --all-features` |
| `cargo fmt` | `cargo fmt --all` |
| — | nouveau job : les cibles de fuzz compilent-elles encore ? |

Deux angles morts fermés :

- **Les 4 crates du workspace** (`benchmark_db`, `ingestor`, `integration_test`, `see_unparsable`) n’étaient lintées ni testées par rien. Elles sont gelées depuis la v5.0.0.
- **La feature `parse_timing`** duplique tout le pipeline de parsing (`parse_decoded_timed`, `decode_timed`). Sans `--all-features`, cette moitié du code n’était jamais compilée en CI.

Le job `fuzz-targets-build` ne fuzze pas : `fuzz/` étant exclu du workspace, rien ne le compilait, et les 5 cibles pourrissaient dès qu’une signature publique changeait. ~1 min pour garantir que le fuzzing planifié reste utilisable.

Ajout du cache cargo (`Swatinem/rust-cache`) pour absorber le surcoût, et `permissions: contents: read` explicité au lieu d’être commenté.

## Fuzzing planifié (`fuzz.yml`)

Nightly à 03:17 UTC, 10 min par cible, 5 cibles en matrice `fail-fast: false` — on veut savoir en une nuit tout ce qui casse, pas seulement le premier.

Deux points de conception qui comptent :

- **Le corpus est conservé d’une nuit sur l’autre** via `actions/cache`. Sans ça, chaque run repart de zéro et ne dépasse jamais la surface la plus superficielle ; avec, la couverture se compose nuit après nuit.
- **Silencieux sauf sur crash.** En cas de crash, l’entrée fautive part en artefact (90 j) et le job échoue, donc notifie. Reproduction : `cargo +nightly fuzz run <cible> <fichier>`.

## Vérification avant push

Les quatre commandes de la nouvelle CI ont été exécutées localement, toutes en sortie 0 :

```
cargo fmt --all -- --check                                          exit=0
cargo clippy --workspace --all-targets --all-features -- -D warnings exit=0
cargo test --workspace --all-features                                exit=0  (744 tests)
cargo build --release --all-features                                 exit=0
```

Les 5 cibles de fuzz compilent. Run local de `parse_linktype` : **10,5 M exécutions à 70 000/s, aucun crash**, couverture 3105 branches, corpus 1667 entrées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)