### PR TITLE
ci: bumper les actions GitHub et surveiller leur dérive avec Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  # Les actions GitHub étaient bloquées en v4 alors que v5+ était sorti, avec
+  # une dépréciation Node annoncée par les runners. Sans surveillance, ça finit
+  # par casser la CI — ou pire, le workflow de publication.
+  #
+  # Cadence mensuelle et groupée : une PR par mois, pas un flux continu. La
+  # protection de branche exige la CI verte, donc une PR Dependabot ne peut
+  # pas casser main même sans relecture immédiate.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -31,7 +31,8 @@ jobs:
         run: cargo tarpaulin --verbose --timeout 120 --out Lcov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./lcov.info
+          # v5 a renommé `file` en `files` (liste séparée par des virgules).
+          files: ./lcov.info

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -53,7 +53,7 @@ jobs:
       # La clé porte le run_id pour toujours réécrire ; restore-keys récupère
       # le corpus de la veille.
       - name: Restore corpus
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: fuzz/corpus/${{ matrix.target }}
           key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -71,7 +71,7 @@ jobs:
       #   cargo +nightly fuzz run <cible> <fichier>
       - name: Upload crashing input
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fuzz-artifacts-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Les runners annonçaient déjà la dépréciation de Node 20 pour `actions/cache@v4` et `actions/checkout@v4` (« forced to run on Node.js 24 »). Elles marchent encore, mais c'est le genre de dérive qui casse la CI — ou le workflow de publication — sans prévenir.

| Action | Avant | Après |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v5 |
| `codecov/codecov-action` | v4 | v5 |

Montée d'**une majeure à la fois** plutôt que jusqu'à la dernière (v7 pour `checkout`), pour garder le saut vérifiable.

⚠️ `codecov-action` v5 a renommé l'entrée `file:` en `files:`. Laisser `file` aurait cassé l'upload de couverture **en silence**. Corrigé dans `coverage.yml`.

## Dependabot

`.github/dependabot.yml`, limité aux actions GitHub : cadence mensuelle, PR groupée, plafond de 3. La protection de branche exigeant la CI verte, une PR Dependabot ne peut pas casser `main` même non relue tout de suite.

Volontairement **pas** de surveillance des crates : `cargo-deny` et `cargo audit` couvrent déjà le risque sécurité, et un flux de PR de dépendances Rust serait du bruit pendant une absence.

## Contexte

Fuzzing local des 5 cibles avant ce commit :

| Cible | Cas exécutés | Crashes |
|---|---|---|
| `parse_quic` | 108 565 887 | 0 |
| `parse_application` | 19 273 361 | 0 |
| `parse_packetflow` | 16 831 522 | 0 |
| `parse_linktype` | 16 712 320 | 0 |
| `parse_dns` | 6 886 572 | 0 |
| **Total** | **168 269 662** | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)