### PR TITLE
docs: cesser de recommander l'API qui présume Ethernet

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -20,7 +20,7 @@ decodees et laisse les couches suivantes a `None` quand c'est necessaire.
 
 ```toml
 [dependencies]
-packet_parser = "7.0.0"
+packet_parser = "8.1.0"
 ```
 
 Pour reproduire les exemples qui decodent de l'hexadecimal:
@@ -28,13 +28,13 @@ Pour reproduire les exemples qui decodent de l'hexadecimal:
 ```toml
 [dependencies]
 hex = "0.4"
-packet_parser = "7.0.0"
+packet_parser = "8.1.0"
 ```
 
 ## Exemple rapide
 
 ```rust
-use packet_parser::PacketFlow;
+use packet_parser::{LinkType, parse};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw = hex::decode(
@@ -43,7 +43,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
          c9c207ef14e3",
     )?;
 
-    let flow = PacketFlow::try_from(raw.as_slice())?;
+    // Toujours passer le LINKTYPE que la capture declare.
+    let flow = parse(LinkType::ETHERNET, &raw)?;
 
     println!("L2: {}", flow.data_link);
 
@@ -69,13 +70,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Cet exemple utilise l'API de compatibilite Ethernet disponible dans la version
-7.0.0 publiee.
+## Choisir le LINKTYPE
 
-## API LINKTYPE explicite (non publiee, cible 7.0.0)
-
-La branche de developpement introduit une entree explicite et fermee par defaut
-pour les lecteurs de captures:
+`parse` est ferme par defaut sur la couche liaison: le LINKTYPE vient de
+l'appelant, il n'est jamais devine a partir des octets. Verifiez-le en amont
+pour refuser une capture avant d'avoir lu un seul paquet:
 
 ```rust
 use packet_parser::{LinkType, is_supported, parse};
@@ -95,7 +94,21 @@ les fichiers. Un adaptateur de capture live doit d'abord normaliser les valeurs
 l'interface referencee par chaque paquet et transmet le LINKTYPE de cette
 interface.
 
-Etat actuel de la branche de developpement:
+### Ne pas utiliser le raccourci Ethernet sur une capture inconnue
+
+`PacketFlow::try_from(&[u8])` et `DataLink::try_from(&[u8])` prennent une simple
+tranche d'octets et **presument Ethernet**. Ils sont conserves pour
+compatibilite et seront retires dans une prochaine version majeure.
+
+Ils n'echouent pas sur une capture non-Ethernet: ils produisent silencieusement
+des donnees fausses. Une trame `LINKTYPE_LINUX_SLL` (ce que donne une capture
+sur l'interface `any` sous Linux) voit ses 16 octets d'en-tete cooked relus
+comme un en-tete Ethernet: l'appel retourne `Ok` avec des adresses MAC
+fabriquees, `internet: None` et `corrupted: None`. Rien ne signale l'erreur, et
+une matrice de flux construite dessus se remplit d'adresses qui n'ont jamais
+existe sur le cable.
+
+LINKTYPE supportes:
 
 | LINKTYPE | Valeur | Etat du decodeur |
 | --- | ---: | --- |
@@ -154,15 +167,15 @@ puissent jamais fabriquer silencieusement des champs Ethernet.
 
 | Besoin | API |
 | --- | --- |
-| Verifier la presence d'un decodeur (cible 7.0.0) | `is_supported(LinkType)` |
-| Parser un paquet avec un type de liaison explicite (cible 7.0.0) | `parse(LinkType, &[u8])` |
-| Parser Ethernet avec le raccourci de compatibilite | `PacketFlow::try_from(&[u8])` |
-| Parser seulement Ethernet/VLAN | `DataLink::try_from(&[u8])` |
+| Verifier la presence d'un decodeur | `is_supported(LinkType)` |
+| **Parser un paquet (voie canonique)** | `parse(LinkType, &[u8])` |
+| Parser Ethernet, raccourci de compatibilite — presume Ethernet, voir plus haut | `PacketFlow::try_from(&[u8])` |
+| Parser seulement Ethernet/VLAN — presume Ethernet, voir plus haut | `DataLink::try_from(&[u8])` |
 | Parser seulement L3 | `Internet::try_from(&[u8])` |
 | Parser seulement L4 | `Transport::try_from(&[u8])` ou `Transport::try_from_parts(...)` |
 | Detacher le resultat du buffer d'origine | `flow.to_owned()` |
 | Recuperer les flux encapsules | `flow.flatten()` |
-| Mesurer un LINKTYPE explicite (cible 7.0.0) | `parse_timed(...)` avec la feature `parse_timing` |
+| Mesurer un LINKTYPE explicite | `parse_timed(...)` avec la feature `parse_timing` |
 | Mesurer Ethernet via l'API de compatibilite | `PacketFlow::try_from_timed(...)` avec la feature `parse_timing` |
 
 `PacketFlow` contient:
@@ -283,7 +296,7 @@ for level in flow.flatten() {
 | Feature | Effet |
 | --- | --- |
 | `doc-diagrams` | Active les diagrammes Rustdoc via `aquamarine` |
-| `parse_timing` | Expose `ParseTiming`, `PacketFlow::try_from_timed` et, sur la branche de developpement, `parse_timed` |
+| `parse_timing` | Expose `ParseTiming`, `parse_timed` et `PacketFlow::try_from_timed` |
 
 La feature `parse_timing` est faite pour les benchmarks. Le chemin normal
 `PacketFlow::try_from` ne mesure pas le temps de parsing.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ next layers as `None` when parsing cannot safely continue.
 
 ```toml
 [dependencies]
-packet_parser = "7.0.0"
+packet_parser = "8.1.0"
 ```
 
 For examples that decode hexadecimal packet dumps:
@@ -30,13 +30,13 @@ For examples that decode hexadecimal packet dumps:
 ```toml
 [dependencies]
 hex = "0.4"
-packet_parser = "7.0.0"
+packet_parser = "8.1.0"
 ```
 
 ## Quick Example
 
 ```rust
-use packet_parser::PacketFlow;
+use packet_parser::{LinkType, parse};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw = hex::decode(
@@ -45,7 +45,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
          c9c207ef14e3",
     )?;
 
-    let flow = PacketFlow::try_from(raw.as_slice())?;
+    // Always pass the LINKTYPE the capture declares.
+    let flow = parse(LinkType::ETHERNET, &raw)?;
 
     println!("L2: {}", flow.data_link);
 
@@ -71,13 +72,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-This example uses the Ethernet compatibility API available in the published
-7.0.0 release.
+## Choosing the LINKTYPE
 
-## Explicit LINKTYPE API (unreleased, target 7.0.0)
-
-The development branch introduces an explicit, fail-closed entry point for
-capture readers:
+`parse` is fail-closed on the link layer: the LINKTYPE comes from the caller and
+is never guessed from the bytes. Check it up front to reject a capture before
+reading a single packet:
 
 ```rust
 use packet_parser::{LinkType, is_supported, parse};
@@ -96,7 +95,20 @@ files. A live-capture adapter must normalize `DLT_*` values first when their
 numeric value differs. For PCAPNG, the capture reader resolves the interface
 referenced by each packet and passes that interface's LINKTYPE.
 
-Current status on the development branch:
+### Do not use the Ethernet shortcut on an unknown capture
+
+`PacketFlow::try_from(&[u8])` and `DataLink::try_from(&[u8])` take a bare byte
+slice and **assume Ethernet**. They are kept for compatibility and will be
+removed in a future major release.
+
+They do not fail on a non-Ethernet capture — they silently produce wrong data. A
+`LINKTYPE_LINUX_SLL` frame (what a capture on the Linux `any` interface yields)
+has its 16 cooked-header bytes reinterpreted as an Ethernet header: the call
+returns `Ok` with fabricated MAC addresses, `internet: None` and
+`corrupted: None`. Nothing signals the mistake, and a flow matrix built from it
+fills up with addresses that never existed on the wire.
+
+Supported LINKTYPEs:
 
 | LINKTYPE | Value | Decoder status |
 | --- | ---: | --- |
@@ -153,15 +165,15 @@ silently manufacture Ethernet fields.
 
 | Need | API |
 | --- | --- |
-| Check whether a link decoder exists (target 7.0.0) | `is_supported(LinkType)` |
-| Parse a packet with an explicit link type (target 7.0.0) | `parse(LinkType, &[u8])` |
-| Parse Ethernet with the compatibility shortcut | `PacketFlow::try_from(&[u8])` |
-| Parse only Ethernet/VLAN | `DataLink::try_from(&[u8])` |
+| Check whether a link decoder exists | `is_supported(LinkType)` |
+| **Parse a packet (canonical)** | `parse(LinkType, &[u8])` |
+| Parse Ethernet, compat shortcut — assumes Ethernet, see above | `PacketFlow::try_from(&[u8])` |
+| Parse only Ethernet/VLAN — assumes Ethernet, see above | `DataLink::try_from(&[u8])` |
 | Parse only L3 | `Internet::try_from(&[u8])` |
 | Parse only L4 | `Transport::try_from(&[u8])` or `Transport::try_from_parts(...)` |
 | Detach the result from the original buffer | `flow.to_owned()` |
 | Iterate over encapsulated flows | `flow.flatten()` |
-| Measure an explicit LINKTYPE (target 7.0.0) | `parse_timed(...)` with the `parse_timing` feature |
+| Measure an explicit LINKTYPE | `parse_timed(...)` with the `parse_timing` feature |
 | Measure Ethernet through the compatibility API | `PacketFlow::try_from_timed(...)` with the `parse_timing` feature |
 
 `PacketFlow` contains:
@@ -281,7 +293,7 @@ for level in flow.flatten() {
 | Feature | Effect |
 | --- | --- |
 | `doc-diagrams` | Enables Rustdoc diagrams through `aquamarine` |
-| `parse_timing` | Exposes `ParseTiming`, `PacketFlow::try_from_timed` and, on the development branch, `parse_timed` |
+| `parse_timing` | Exposes `ParseTiming`, `parse_timed` and `PacketFlow::try_from_timed` |
 
 The `parse_timing` feature is intended for benchmarks. The normal
 `PacketFlow::try_from` path does not measure parsing time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,86 +11,109 @@
 //! (Ethernet II) and moving down through the network, transport, and application layers.
 //!
 //! ## Features
-//! - **Multi-layer analysis**: Supports data link, network, transport, and application layers.
-//! - **Error management**: Detailed error handling to facilitate debugging.
-//! - **Packet validation**: Built-in verification mechanisms to ensure data integrity.
-//! - **Modular architecture**: Easily extendable to support new protocols.
+//! - **Multi-layer analysis**: link, internet, transport and application layers.
+//! - **Zero-copy**: [`PacketFlow`] borrows the input buffer; no payload is copied.
+//! - **Fail-closed on the link layer**: the LINKTYPE is supplied by the caller,
+//!   never guessed from the bytes.
+//! - **Fail-soft above it**: an unsupported or malformed upper layer leaves that
+//!   layer `None` instead of failing the whole parse.
+//! - **Modular architecture**: easily extendable to support new protocols.
 //!
-//! ## Usage Example
+//! ## Usage
+//!
+//! [`fn@parse`] is the entry point. It takes the LINKTYPE of the capture — the
+//! value stored in the PCAP/PCAPNG file — and exactly one packet, without any
+//! record header.
 //!
 //! ```rust
-//! use packet_parser::DataLink;
-//! use hex::decode;
+//! use packet_parser::{LinkType, parse};
 //!
-//! let hex_dump_data = "feaa81e86d1efeaa818ec864080045500034000000003d06206b36e6700dac140a0201bbc1087d7f02aa4e2b998e80100081748300000101080a9373c9c207ef14e3";
-//! let packet = decode(hex_dump_data).expect("Hexadecimal conversion failed");
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let frame = hex::decode(
+//!     "feaa81e86d1efeaa818ec864080045500034000000003d06206b36e6700d\
+//!      ac140a0201bbc1087d7f02aa4e2b998e80100081748300000101080a9373\
+//!      c9c207ef14e3",
+//! )?;
 //!
-//! match DataLink::try_from(packet.as_slice()) {
-//!     Ok(datalink) => println!("{:?}", datalink),
-//!     Err(e) => eprintln!("Parsing error: {:?}", e),
+//! let flow = parse(LinkType::ETHERNET, &frame)?;
+//!
+//! println!("L2: {}", flow.data_link);
+//!
+//! if let Some(internet) = &flow.internet {
+//!     println!("L3: {} {:?} -> {:?}",
+//!         internet.protocol_name, internet.source, internet.destination);
 //! }
+//! if let Some(transport) = &flow.transport {
+//!     println!("L4: {:?} {:?} -> {:?}",
+//!         transport.protocol, transport.source_port, transport.destination_port);
+//! }
+//! if let Some(application) = &flow.application {
+//!     println!("L7: {}", application.application_protocol);
+//! }
+//! # Ok(())
+//! # }
 //! ```
-//! ## Packet Structure
 //!
-//! The library parses packets into a hierarchical structure that can be represented as:
+//! Use [`is_supported`] to check a LINKTYPE before feeding a whole capture:
+//!
+//! ```rust
+//! use packet_parser::{LinkType, is_supported};
+//!
+//! assert!(is_supported(LinkType::ETHERNET));
+//! assert!(is_supported(LinkType::LINUX_SLL));
+//! assert!(!is_supported(LinkType(0xdead)));
+//! ```
+//!
+//! ### Do not guess the LINKTYPE
+//!
+//! [`PacketFlow::try_from`] and [`DataLink::try_from`] accept a bare `&[u8]` and
+//! **assume [`LinkType::ETHERNET`]**. They are kept for compatibility and will be
+//! removed in a future major release.
+//!
+//! Feeding them a non-Ethernet capture does not fail — it silently produces
+//! wrong data. A `LINKTYPE_LINUX_SLL` frame (what a capture on the `any`
+//! interface yields) has its 16 cooked-header bytes reinterpreted as an Ethernet
+//! header, so the parse returns `Ok` with fabricated MAC addresses,
+//! `internet: None` and `corrupted: None`. Nothing signals the mistake.
+//!
+//! Always pass the LINKTYPE the capture actually declares.
+//!
+//! ## What a parse returns
 //!
 //! ```text
-//! Packet
-//! ├── DataLink (Ethernet II)
-//! │   ├── source_mac: MacAddress
-//! │   ├── destination_mac: MacAddress
-//! │   └── ether_type: EtherType
-//! │
-//! ├── Network (IPv4/IPv6)
-//! │   ├── source_ip: IpAddr
-//! │   ├── destination_ip: IpAddr
-//! │   └── protocol: IpProtocol
-//! │
-//! ├── Transport (TCP/UDP/ICMP)
-//! │   ├── source_port: Option<u16>
-//! │   ├── destination_port: Option<u16>
-//! │   └── protocol: TransportProtocol
-//! │
-//! └── Application
-//!     ├── protocol: ApplicationProtocol
-//!     └── payload: Vec<u8>
+//! PacketFlow<'a>
+//! ├── data_link:   LinkLayer<'a>              (mandatory — Ethernet, SLL, SLL2, RAW)
+//! ├── internet:    Option<Internet<'a>>       source / destination / protocol_name
+//! │                                           / payload_protocol / payload / details
+//! ├── transport:   Option<Transport<'a>>      protocol / source_port / destination_port
+//! │                                           / payload / details
+//! ├── application: Option<Application>        application_protocol: &'static str
+//! ├── inner:       Option<Box<PacketFlow<'a>>>  packet carried inside a tunnel
+//! └── corrupted:   Option<CorruptedLayer>     set when a recognized layer held
+//!                                             invalid bytes
 //! ```
 //!
-//! ## Example Flattened Struct
+//! The application layer is a **classification, not a decode**: it reports the
+//! detected protocol name, not a parsed message.
 //!
-//! For easier access to all fields, you can use a flattened structure:
+//! ## Reading the outcome
 //!
-//! ```rust
-//! use std::net::IpAddr;
-//! use pnet::packet::ethernet::EtherType;
-//! use pnet::packet::ip::IpNextHeaderProtocol as IpProtocol;
-//! use packet_parser::parse::application::protocols::ApplicationProtocol;
-//! use packet_parser::parse::transport::protocols::TransportProtocol;
+//! Only the link layer can fail the parse: an unsupported LINKTYPE yields
+//! `Err(ParseError)`. Above it, three outcomes are distinct and must not be
+//! confused:
 //!
-//! pub struct FlattenedPacket<'a> {
-//!     // Data Link Layer (Ethernet)
-//!     pub source_mac: String,
-//!     pub destination_mac: String,
-//!     pub ether_type: EtherType,
-//!     
-//!     // Network Layer
-//!     pub source_ip: IpAddr,
-//!     pub destination_ip: IpAddr,
-//!     pub ip_protocol: IpProtocol,
-//!     
-//!     // Transport Layer
-//!     pub source_port: Option<u16>,
-//!     pub destination_port: Option<u16>,
-//!     pub transport_protocol: TransportProtocol,
-//!     
-//!     // Application Layer
-//!     pub application_protocol: Option<ApplicationProtocol<'a>>,
-//!     pub payload: Vec<u8>,
-//! }
-//! ```
+//! - **layer present** — it was recognized and decoded;
+//! - **layer `None`, `corrupted` `None`** — the protocol is not supported, and
+//!   nothing above it could be reached;
+//! - **layer `None`, `corrupted` `Some`** — the layer *was* recognized but
+//!   carried invalid bytes. [`CorruptedLayer`] names which one.
 //!
-//! This flattened structure provides direct access to all packet fields without
-//! having to navigate through multiple layers of nested enums and structs.
+//! ## Owned flows
+//!
+//! [`PacketFlow`] borrows the input buffer. To store a flow, send it across
+//! threads or serialize it, convert it with [`PacketFlow::to_owned`], which
+//! returns an [`owned::PacketFlowOwned`]. Note that the owned form drops the
+//! payloads and the per-layer `details`.
 
 /// Module handling format and integrity checks for packets.
 pub mod checks;

--- a/src/parse/data_link/mod.rs
+++ b/src/parse/data_link/mod.rs
@@ -97,6 +97,13 @@ pub struct DataLink<'a> {
     pub payload: &'a [u8],
 }
 
+/// Parses `packets` as an **Ethernet II** frame.
+///
+/// Low-level entry point, kept for compatibility. It only checks that the
+/// buffer is long enough — it never verifies that the bytes *are* Ethernet, so
+/// a capture in another LINKTYPE yields a successful parse holding fabricated
+/// MAC addresses. Prefer [`fn@crate::parse`], which dispatches on the LINKTYPE
+/// declared by the capture and refuses the ones it does not support.
 impl<'a> TryFrom<&'a [u8]> for DataLink<'a> {
     type Error = DataLinkError;
 

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -75,7 +75,7 @@ pub fn parse(link_type: LinkType, bytes: &[u8]) -> Result<PacketFlow<'_>, ParseE
     PacketFlow::parse_decoded(link::decode(link_type, bytes)?, 0)
 }
 
-/// Timed counterpart of [`parse`], using the exact same link-type dispatcher.
+/// Timed counterpart of [`fn@parse`], using the exact same link-type dispatcher.
 #[cfg(feature = "parse_timing")]
 #[inline(always)]
 pub fn parse_timed<'a>(
@@ -170,6 +170,23 @@ pub struct PacketFlow<'a> {
     pub corrupted: Option<CorruptedLayer>,
 }
 
+/// Parses `bytes` **assuming [`LinkType::ETHERNET`]**.
+///
+/// Kept for compatibility; prefer [`fn@parse`], which takes the LINKTYPE the
+/// capture actually declares. This impl will be removed in a future major
+/// release.
+///
+/// # This does not fail on a non-Ethernet capture — it fabricates data
+///
+/// There is no plausibility check: any buffer of at least 14 bytes is read as
+/// an Ethernet header. Given a `LINKTYPE_LINUX_SLL` frame — what a capture on
+/// the Linux `any` interface produces — the 16 cooked-header bytes are
+/// reinterpreted as MAC addresses and an EtherType. The call returns `Ok` with
+/// invented MAC addresses, `internet: None` and `corrupted: None`. **Nothing
+/// signals the mistake**, and a flow matrix built from it fills up with
+/// addresses that never existed on the wire.
+///
+/// Reach for this only when the capture is known to be Ethernet.
 impl<'a> TryFrom<&'a [u8]> for PacketFlow<'a> {
     type Error = ParseError;
 


### PR DESCRIPTION
La documentation mettait en avant la voie qui **fabrique des données de liaison**, et reléguait l'API canonique sous un titre « unreleased, target 7.0.0 » alors que `Cargo.toml` est en 8.1.0 et que le CHANGELOG la documente comme livrée. Toute la valeur du dispatch fail-closed de la 7.0.0 était annulée par le raccourci que la doc conseillait.

Closes #18
Closes #28

## `src/lib.rs`

| Avant | Après |
|---|---|
| Exemple bâti sur `DataLink::try_from` | `parse(LinkType::ETHERNET, &raw)` |
| Arbre décrivant `Application { protocol, payload: Vec<u8> }` | La forme réelle de `PacketFlow`, champ par champ |
| Bloc `FlattenedPacket` | Supprimé |
| — | Section « Do not guess the LINKTYPE » |
| — | Lecture des trois issues au-dessus de L2 |

Deux corrections de fond :

- **`Application` n’a jamais eu la forme documentée.** Le vrai type est `Application { application_protocol: &'static str }` — une classification, pas un décodage. L’arbre annonçait un `payload: Vec<u8>` inexistant.
- **Le bloc `FlattenedPacket` documentait un type qui n’existe pas**, et importait `pnet` — une **dev-dependency**. Un utilisateur qui copiait l’exemple obtenait `E0432: unresolved import`.

## `parse/mod.rs`, `data_link/mod.rs`

Doc-comment sur les deux `TryFrom<&[u8]>`, là où la surprise a lieu :

> Given a `LINKTYPE_LINUX_SLL` frame — what a capture on the Linux `any` interface produces — the 16 cooked-header bytes are reinterpreted as MAC addresses and an EtherType. The call returns `Ok` with invented MAC addresses, `internet: None` and `corrupted: None`. **Nothing signals the mistake.**

Pas de `#[deprecated]` dans cette PR : l’attribut ferait échouer `clippy -D warnings` sur les tests internes qui utilisent encore ces impls. C’est un changement d’API, à traiter séparément.

## `README.md`, `README-fr.md`

- `packet_parser = "7.0.0"` → `"8.1.0"`
- Le Quick Example utilise `parse(LinkType, …)`
- « Explicit LINKTYPE API (unreleased, target 7.0.0) » → « Choosing the LINKTYPE » ; les `(target 7.0.0)` des tableaux disparaissent ; `parse()` est marquée voie canonique et les deux raccourcis renvoient à l’avertissement
- La feature `parse_timing` ne parle plus de « development branch »

## Vérification

Le Quick Example a été **copié tel quel** dans un exemple compilé et exécuté, comme le ferait un utilisateur :

```
L2: ... Ethertype: IPv4, VLAN: None, Payload Length: 52
L3: IPv4 Some(54.230.112.13) -> Some(172.20.10.2)
L4: Tcp Some(443) -> Some(49416)
```

744 tests + 13 doctests verts, clippy `--workspace --all-targets --all-features` silencieux, `cargo doc --no-deps` **sans warning** — les liens `[`+"`"+`parse`+"`"+`]` ont dû être désambiguïsés en `[`+"`"+`fn@parse`+"`"+`]`, `parse` étant à la fois une fonction et un module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)