### PR TITLE
docs: resynchroniser roadmap et sprints sur l'etat reel

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,7 @@ l'epic **#76** plutot que de declencher trois majeures successives :
 | #21 | `#[non_exhaustive]` sur les ~34 enums d'erreur qui ne l'ont pas | volet public **livre**, #21 close le 2026-08-15 ; reste le volet SemVer |
 | #24 | Variantes distinctes pour `validate_tcp_flags` / `validate_tcp_reserved` (`TcpError` n'est pas `non_exhaustive`) | ouvert |
 | #48 | Suppression de `QuicPacketType::Unknown` et de sa branche morte | #48 close ; inaccessibilite verrouillee par test (#75), reste la suppression |
+| sprint_02 | Unifier les deux chemins d'erreur de liaison de `ParseError` (`InvalidDataLink` historique vs `InvalidLinkLayer`) | reliquat de phase 1, reverse dans #76 |
 
 Tant que #76 n'est pas ouvert en chantier, ces trois points restent
 volontairement en l'etat. Rien d'autre n'est connu comme bloque par la
@@ -133,7 +134,10 @@ En parallele des protocoles : solder #56 (golden tests manquants), qui est
 de la dette plus que de la feature.
 
 Sprints : `sprint_01.md` (methode de travail) et `sprint_02.md`
-(architecture multi-LINKTYPE) sont tous deux soldes. Aucun sprint actif.
+(architecture multi-LINKTYPE) sont tous deux soldes sur leur definition de
+termine. Aucun sprint actif. Le seul reliquat de sprint_02 — l'unification des
+deux chemins d'erreur de liaison — est une rupture d'API et vit desormais dans
+#76 (§1 bis).
 
 ## 4. Regles de la fenetre de stabilite
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@ concernes et critere d'acceptation.
 | Epic | Sujet | Etat |
 |---|---|---|
 | #38 | Nettoyage d'API pour la 10.0.0 | ✅ clos (livre en 10.0.0) |
-| #46 | Durcissements de validation (http, quic, dhcp, srvloc) | ouvert — #47 clos |
+| #46 | Durcissements de validation (http, quic, dhcp, srvloc) | ouvert — #47 clos, #48 clos ; restent #49 et #50 |
 | #51 | Completer les parseurs (dispatch GIOP, body SLPv2, Retry QUIC) | ouvert |
 | #56 | Golden tests manquants (ethernet_ip, giop, quic) | ouvert — bloque par #74 |
 | #60 | Zero-copy integral (rdata DNS, Vec postgresql/opcua/http) | ouvert |
@@ -64,7 +64,7 @@ l'epic **#76** plutot que de declencher trois majeures successives :
 |---|---|---|
 | #21 | `#[non_exhaustive]` sur les ~34 enums d'erreur qui ne l'ont pas | volet public **livre**, #21 close le 2026-08-15 ; reste le volet SemVer |
 | #24 | Variantes distinctes pour `validate_tcp_flags` / `validate_tcp_reserved` (`TcpError` n'est pas `non_exhaustive`) | ouvert |
-| #48 | Suppression de `QuicPacketType::Unknown` et de sa branche morte | inaccessibilite deja verrouillee par test (#75) |
+| #48 | Suppression de `QuicPacketType::Unknown` et de sa branche morte | #48 close ; inaccessibilite verrouillee par test (#75), reste la suppression |
 
 Tant que #76 n'est pas ouvert en chantier, ces trois points restent
 volontairement en l'etat. Rien d'autre n'est connu comme bloque par la

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,14 @@
 # Roadmap packet_parser
 
-Etat au 2026-08-04 : la 10.0.0 est publiee (decodage COTP complet, enveloppe
+Etat au 2026-08-15 : la 10.0.0 est publiee (decodage COTP complet, enveloppe
 S7Comm stricte, nettoyage de l'API morte). Elle ouvre une **fenetre de
 stabilite** : tout ce qui suit est realisable sans nouvelle version majeure,
 et l'objectif est de tenir 6 a 12 mois sans rupture d'API.
+
+Non encore publie depuis : ICMPv4, ICMPv6 (dont Router Solicitation /
+Advertisement), SSH, le correctif `require_version` HTTP et le passage de
+`Cargo.toml` a une liste `include`. Voir la section « Non publie » du
+CHANGELOG.
 
 Chaque ajout suit la methode canonique (`METHODE_AJOUT_PROTOCOLE.md`) :
 extract_* par champ dans checks, TryFrom lineaire, golden tests sur trames
@@ -18,16 +23,22 @@ concernes et critere d'acceptation.
 | Epic | Sujet | Etat |
 |---|---|---|
 | #38 | Nettoyage d'API pour la 10.0.0 | ✅ clos (livre en 10.0.0) |
-| #46 | Durcissements de validation (http, quic, dhcp, srvloc) | ouvert |
+| #46 | Durcissements de validation (http, quic, dhcp, srvloc) | ouvert — #47 clos |
 | #51 | Completer les parseurs (dispatch GIOP, body SLPv2, Retry QUIC) | ouvert |
-| #56 | Golden tests manquants (ethernet_ip, giop, quic) | ouvert |
+| #56 | Golden tests manquants (ethernet_ip, giop, quic) | ouvert — bloque par #74 |
 | #60 | Zero-copy integral (rdata DNS, Vec postgresql/opcua/http) | ouvert |
 | #64 | Detection hors port standard : API « Decode As » + verbes non-ambigus FTP/SMTP/NNTP | ouvert |
 | #67 | Nouveaux protocoles : LLMNR (#68) et SSDP (#69) | ouvert |
-| #70 | Generaliser la regression tshark (modbus, dns, tls) | ouvert |
+| #70 | Generaliser la regression tshark (modbus, dns, tls) | ouvert — bloque par #74 |
 
-Priorite au sein des chantiers : #56 (dette vis-a-vis de la regle
-« trames reelles obligatoires »).
+Priorite au sein des chantiers : **#74 d'abord**. `examples/scan_pcaps.rs:70`
+appelle `get_datalink()` une seule fois sur un pcapng a 313 IDB et quatre
+LINKTYPE, si bien que `The-Ultimate-PCAP.pcapng` compte zero trame et que son
+materiel (542 SSH, 99 SSDP, 18 LLMNR) est invisible. Tant qu'il tient, #56 et
+#70 travaillent sur un corpus ampute, et #68/#69 n'ont pas leurs trames de
+reference.
+
+Vient ensuite #56, dette vis-a-vis de la regle « trames reelles obligatoires ».
 
 #55 a ete ferme le 2026-08-12 : il decrivait un etat perime. La detection
 TLS est cablee depuis le commit 5b12cf7 (2025-11-20) par probing aveugle
@@ -42,6 +53,22 @@ etiquette 7 « TCP » comme nous ; les 5 autres ne deviennent TLS que par
 reassemblage TCP (tcp.segment.count 2 a 4), hors de portee d'un parseur
 stateless. Meme frontiere que le QUIC Short Header documente dans
 `src/parse/mod.rs`. Rien a voir avec ECH.
+
+## 1 bis. Ruptures en attente (#76)
+
+Trois changements identifies touchent une surface publique et sont donc
+incompatibles avec la fenetre de stabilite du §4. Ils sont regroupes dans
+l'epic **#76** plutot que de declencher trois majeures successives :
+
+| Issue | Rupture | Etat |
+|---|---|---|
+| #21 | `#[non_exhaustive]` sur les ~34 enums d'erreur qui ne l'ont pas | volet public **livre**, #21 close le 2026-08-15 ; reste le volet SemVer |
+| #24 | Variantes distinctes pour `validate_tcp_flags` / `validate_tcp_reserved` (`TcpError` n'est pas `non_exhaustive`) | ouvert |
+| #48 | Suppression de `QuicPacketType::Unknown` et de sa branche morte | inaccessibilite deja verrouillee par test (#75) |
+
+Tant que #76 n'est pas ouvert en chantier, ces trois points restent
+volontairement en l'etat. Rien d'autre n'est connu comme bloque par la
+fenetre de stabilite.
 
 ## 2. Nouveaux protocoles proposes
 
@@ -85,16 +112,28 @@ d'abord si `4SICS-GeekLounge-151020.pcap` contient deja du DNP3/IEC104.
 
 ## 3. Ordre recommande
 
-1. **ICMP** — captures pretes, trou fonctionnel.
+Livres depuis le cadrage de cette liste, non encore publies :
+
+- **ICMP** — ICMPv4 et ICMPv6, dont Router Solicitation / Advertisement.
+- **SSH** — sur les trames de banniere. Limite connue consignee au
+  CHANGELOG : un parseur stateless en identifie huit sur les 542 trames
+  qu'un dissecteur a etat etiquette SSH dans `The-Ultimate-PCAP`.
+
+Reste a faire, dans l'ordre :
+
+1. **#74** — le deblocage de corpus (voir §1). Prealable a #56, #70, #68
+   et #69.
 2. **UMAS** — differenciateur ICS, s'appuie sur Modbus.
-3. **SSH** — ratio valeur/effort imbattable.
-4. **DNP3** — ouvre le secteur energie.
-5. **RDP** — rentabilise TPKT/COTP.
-6. RADIUS, NetBIOS, LLMNR (#68), SSDP (#69) au fil de l'eau.
-7. Tier 2 restant (IEC 104, BACnet, GOOSE/SV), puis Tier 3 restant.
+3. **DNP3** — ouvre le secteur energie.
+4. **RDP** — rentabilise TPKT/COTP.
+5. RADIUS, NetBIOS, LLMNR (#68), SSDP (#69) au fil de l'eau.
+6. Tier 2 restant (IEC 104, BACnet, GOOSE/SV), puis Tier 3 restant.
 
 En parallele des protocoles : solder #56 (golden tests manquants), qui est
 de la dette plus que de la feature.
+
+Sprints : `sprint_01.md` (methode de travail) et `sprint_02.md`
+(architecture multi-LINKTYPE) sont tous deux soldes. Aucun sprint actif.
 
 ## 4. Regles de la fenetre de stabilite
 

--- a/sprint_02.md
+++ b/sprint_02.md
@@ -1,13 +1,25 @@
 # Sprint 02 - Architecture de parsing multi-LINKTYPE extensible
 
-> Statut : **termine** le 2026-08-15. Les quinze criteres de la « definition de
-> termine » sont satisfaits ; les deux derniers (`cargo fmt --check` et le
-> rejeu sans panique des cibles de fuzz) ont ete verifies a cette date.
+> Statut : **solde le 2026-08-15 sur sa definition de termine**, avec un
+> reliquat identifie et reverse dans l'epic #76.
+>
+> Les quinze criteres de la « definition de termine » sont satisfaits ; les
+> deux derniers (`cargo fmt --check` et le rejeu sans panique des cibles de
+> fuzz) ont ete verifies a cette date.
 >
 > La matrice de support cible est fermee : `decoder_for`
 > (`src/parse/link/mod.rs:51`) cable Ethernet (1), RAW (101), IPV4 (228),
 > IPV6 (229), SLL (113) et SLL2 (276) ; tout autre LINKTYPE, Bluetooth H4
 > (201) inclus, est preserve puis refuse par `UnsupportedLinkType`.
+>
+> **Reliquat.** La derniere case de la phase 1 — « remplacer les erreurs de
+> liaison provisoires par le contrat final » — reste ouverte, et le fichier ne
+> pretend pas le contraire. `ParseError` porte aujourd'hui deux chemins
+> paralleles : `InvalidDataLink(DataLinkError)` pour Ethernet, historique et
+> sans `#[non_exhaustive]`, et `InvalidLinkLayer(LinkLayerError)` pour les
+> decodeurs recents, qui applique bien le contrat du §« Contrat d'erreur ».
+> Les unifier modifie une surface publique : c'est une rupture, donc hors
+> fenetre de stabilite. Suivi dans #76 avec les trois autres.
 >
 > Date de cadrage : 2026-07-13
 >

--- a/sprint_02.md
+++ b/sprint_02.md
@@ -1,6 +1,13 @@
 # Sprint 02 - Architecture de parsing multi-LINKTYPE extensible
 
-> Statut : actif
+> Statut : **termine** le 2026-08-15. Les quinze criteres de la « definition de
+> termine » sont satisfaits ; les deux derniers (`cargo fmt --check` et le
+> rejeu sans panique des cibles de fuzz) ont ete verifies a cette date.
+>
+> La matrice de support cible est fermee : `decoder_for`
+> (`src/parse/link/mod.rs:51`) cable Ethernet (1), RAW (101), IPV4 (228),
+> IPV6 (229), SLL (113) et SLL2 (276) ; tout autre LINKTYPE, Bluetooth H4
+> (201) inclus, est preserve puis refuse par `UnsupportedLinkType`.
 >
 > Date de cadrage : 2026-07-13
 >
@@ -506,12 +513,16 @@ formatage des commits concurrents doivent egalement etre corriges hors MW-05.
   sont presents.
 - [x] La matrice de support et la migration sont documentees en anglais et en
   francais.
-- [ ] `cargo fmt --check` passe sur le HEAD integre.
+- [x] `cargo fmt --check` passe sur le HEAD integre.
 - [x] `cargo clippy --all-targets --all-features -- -D warnings` passe.
 - [x] `cargo test` passe.
 - [x] `cargo test --features parse_timing` passe.
-- [ ] Les cibles de fuzzing du parsing paquet et des nouveaux decodeurs ne
-  paniquent pas sur le corpus de regression.
+- [x] Les cibles de fuzzing du parsing paquet et des nouveaux decodeurs ne
+  paniquent pas sur le corpus de regression. Verifie le 2026-08-15 : les sept
+  cibles (`parse_application`, `parse_cotp`, `parse_dns`, `parse_linktype`,
+  `parse_packetflow`, `parse_quic`, `parse_s7comm`) rejouent leur corpus avec
+  `cargo +nightly fuzz run <cible> -- -runs=0`, soit 9 898 entrees, sans une
+  seule panique.
 
 ## Hors perimetre
 


### PR DESCRIPTION
Volet local du sync demande. Le volet GitHub est deja applique : epic #76
cree, #21 fermee, #23 et #48 commentees.

## ROADMAP.md

Le fichier datait du 2026-08-04 et avait derive sur trois points.

**ICMP et SSH etaient encore dans « ordre recommande »** alors qu'ils sont
livres et en attente de publication. Deplaces dans une liste « livres, non
publies », avec la limite connue de SSH (huit trames de banniere identifiees
sur les 542 qu'un dissecteur a etat etiquette SSH).

**Le tableau d'epics ne signalait aucune dependance.** #56 et #70 sont
bloques par #74, et #47 est desormais clos dans #46. #74 devient la priorite
explicite : tant que `examples/scan_pcaps.rs:70` appelle `get_datalink()` une
seule fois sur un pcapng a 313 IDB, `The-Ultimate-PCAP.pcapng` compte zero
trame, #56 et #70 travaillent sur un corpus ampute, et #68/#69 n'ont pas
leurs trames de reference.

**Nouvelle section 1 bis** renvoyant vers l'epic #76, qui regroupe les trois
ruptures d'API en attente (#21 `non_exhaustive`, #24 variantes `TcpError`,
#48 variante `QuicPacketType::Unknown`). Elles etaient eparpillees et chacune
en tension silencieuse avec la regle de fenetre de stabilite du §4.

## sprint_02.md

Passe de « actif » a **termine**. Il restait deux cases non cochees dans sa
definition de termine ; toutes deux ont ete verifiees a cette date :

- `cargo fmt --check` passe ;
- les sept cibles de fuzz rejouent leur corpus de regression sans une seule
  panique — `cargo +nightly fuzz run <cible> -- -runs=0` sur
  `parse_application`, `parse_cotp`, `parse_dns`, `parse_linktype`,
  `parse_packetflow`, `parse_quic` et `parse_s7comm`, soit **9 898 entrees**,
  exit 0.

La matrice de support cible est bien fermee : `decoder_for`
(`src/parse/link/mod.rs:51`) cable Ethernet (1), RAW (101), IPV4 (228),
IPV6 (229), SLL (113) et SLL2 (276) ; tout autre LINKTYPE, Bluetooth H4 (201)
inclus, est preserve puis refuse par `UnsupportedLinkType`.

Plus aucun sprint actif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
